### PR TITLE
Refactor MapsScreen modals into modular components

### DIFF
--- a/app/components/maps/EditOrganizationModal.tsx
+++ b/app/components/maps/EditOrganizationModal.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, ScrollView, StyleSheet, TextInput } from 'react-native';
+import Icon from '@expo/vector-icons/MaterialIcons';
+
+import type { Organization } from '../../types/organization';
+
+type ThemeColors = {
+  primary: string;
+  secondary: string;
+  background: string;
+  surface: string;
+  text: string;
+  border: string;
+  success: string;
+  warning: string;
+  error: string;
+};
+
+export type EditFormState = {
+  name: string;
+  address: string;
+  status: string;
+  currentStatusDetails: string;
+  assignee: string;
+};
+
+type Props = {
+  visible: boolean;
+  colors: ThemeColors;
+  formData: EditFormState;
+  onChange: (field: keyof EditFormState, value: string) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+  organizationName?: Organization['name'];
+};
+
+const EditOrganizationModal: React.FC<Props> = ({
+  visible,
+  colors,
+  formData,
+  onChange,
+  onClose,
+  onSubmit,
+  organizationName,
+}) => (
+  <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+    <View style={styles.modalOverlay}>
+      <View style={[styles.modalContent, { backgroundColor: colors.surface }]}> 
+        <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}> 
+          <View>
+            <Text style={[styles.modalTitle, { color: colors.text }]}>Edit Organization</Text>
+            {organizationName ? (
+              <Text style={[styles.modalSubtitle, { color: colors.secondary }]} numberOfLines={1}>
+                {organizationName}
+              </Text>
+            ) : null}
+          </View>
+          <TouchableOpacity onPress={onClose} accessibilityRole="button">
+            <Icon name="close" size={24} color={colors.text} />
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView style={styles.modalBody} showsVerticalScrollIndicator={false}>
+          <Text style={[styles.inputLabel, { color: colors.text }]}>Name</Text>
+          <TextInput
+            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+            value={formData.name}
+            onChangeText={(value) => onChange('name', value)}
+            placeholder="Organization name"
+            placeholderTextColor={colors.secondary}
+          />
+
+          <Text style={[styles.inputLabel, { color: colors.text }]}>Address</Text>
+          <TextInput
+            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+            value={formData.address}
+            onChangeText={(value) => onChange('address', value)}
+            placeholder="Organization address"
+            placeholderTextColor={colors.secondary}
+          />
+
+          <Text style={[styles.inputLabel, { color: colors.text }]}>Status</Text>
+          <TextInput
+            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+            value={formData.status}
+            onChangeText={(value) => onChange('status', value)}
+            placeholder="Current status"
+            placeholderTextColor={colors.secondary}
+          />
+
+          <Text style={[styles.inputLabel, { color: colors.text }]}>Status Details</Text>
+          <TextInput
+            style={[styles.textArea, { borderColor: colors.border, color: colors.text }]}
+            value={formData.currentStatusDetails}
+            onChangeText={(value) => onChange('currentStatusDetails', value)}
+            placeholder="Additional details"
+            placeholderTextColor={colors.secondary}
+            multiline
+          />
+
+          <Text style={[styles.inputLabel, { color: colors.text }]}>Assignee</Text>
+          <TextInput
+            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+            value={formData.assignee}
+            onChangeText={(value) => onChange('assignee', value)}
+            placeholder="Assigned to"
+            placeholderTextColor={colors.secondary}
+          />
+        </ScrollView>
+
+        <View style={[styles.modalFooter, { borderTopColor: colors.border }]}> 
+          <TouchableOpacity
+            style={[styles.submitButton, { backgroundColor: colors.primary }]}
+            onPress={onSubmit}
+            activeOpacity={0.85}
+          >
+            <Icon name="save" size={20} color="#fff" />
+            <Text style={styles.submitText}>Save Changes</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  </Modal>
+);
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    maxHeight: '85%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 20,
+    borderBottomWidth: 1,
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  modalSubtitle: {
+    marginTop: 4,
+    fontSize: 12,
+  },
+  modalBody: {
+    padding: 20,
+  },
+  inputLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  textInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  textArea: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    minHeight: 100,
+    textAlignVertical: 'top',
+    marginBottom: 16,
+  },
+  modalFooter: {
+    padding: 20,
+    borderTopWidth: 1,
+  },
+  submitButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  submitText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    marginLeft: 8,
+  },
+});
+
+export default EditOrganizationModal;
+

--- a/app/components/maps/MeetingRequestModal.tsx
+++ b/app/components/maps/MeetingRequestModal.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, ScrollView, StyleSheet, TextInput } from 'react-native';
+import Icon from '@expo/vector-icons/MaterialIcons';
+
+type ThemeColors = {
+  primary: string;
+  secondary: string;
+  background: string;
+  surface: string;
+  text: string;
+  border: string;
+  success: string;
+  warning: string;
+  error: string;
+};
+
+export type MeetingFormState = {
+  title: string;
+  description: string;
+  scheduledTime: string;
+};
+
+type Props = {
+  visible: boolean;
+  colors: ThemeColors;
+  formData: MeetingFormState;
+  onChange: (field: keyof MeetingFormState, value: string) => void;
+  onSubmit: () => void;
+  onClose: () => void;
+};
+
+const MeetingRequestModal: React.FC<Props> = ({ visible, colors, formData, onChange, onSubmit, onClose }) => (
+  <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+    <View style={styles.modalOverlay}>
+      <View style={[styles.modalContent, { backgroundColor: colors.surface }]}> 
+        <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}> 
+          <Text style={[styles.modalTitle, { color: colors.text }]}>Schedule Meeting</Text>
+          <TouchableOpacity onPress={onClose} accessibilityRole="button">
+            <Icon name="close" size={24} color={colors.text} />
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView style={styles.modalBody} showsVerticalScrollIndicator={false}>
+          <Text style={[styles.inputLabel, { color: colors.text }]}>Meeting Title *</Text>
+          <TextInput
+            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+            value={formData.title}
+            onChangeText={(value) => onChange('title', value)}
+            placeholder="Enter meeting title"
+            placeholderTextColor={colors.secondary}
+          />
+
+          <Text style={[styles.inputLabel, { color: colors.text }]}>Description</Text>
+          <TextInput
+            style={[styles.textArea, { borderColor: colors.border, color: colors.text }]}
+            value={formData.description}
+            onChangeText={(value) => onChange('description', value)}
+            placeholder="Enter meeting description"
+            placeholderTextColor={colors.secondary}
+            multiline
+            numberOfLines={3}
+          />
+
+          <Text style={[styles.inputLabel, { color: colors.text }]}>Scheduled Time *</Text>
+          <TextInput
+            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+            value={formData.scheduledTime}
+            onChangeText={(value) => onChange('scheduledTime', value)}
+            placeholder="YYYY-MM-DD HH:MM"
+            placeholderTextColor={colors.secondary}
+          />
+        </ScrollView>
+
+        <View style={[styles.modalFooter, { borderTopColor: colors.border }]}> 
+          <TouchableOpacity
+            style={[styles.submitButton, { backgroundColor: colors.success }]}
+            onPress={onSubmit}
+            activeOpacity={0.85}
+          >
+            <Icon name="send" size={20} color="#fff" />
+            <Text style={styles.submitText}>Submit Request</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  </Modal>
+);
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    maxHeight: '80%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 20,
+    borderBottomWidth: 1,
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  modalBody: {
+    padding: 20,
+  },
+  inputLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  textInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  textArea: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    minHeight: 80,
+    textAlignVertical: 'top',
+    marginBottom: 16,
+  },
+  modalFooter: {
+    padding: 20,
+    borderTopWidth: 1,
+  },
+  submitButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+  },
+  submitText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    marginLeft: 8,
+  },
+});
+
+export default MeetingRequestModal;
+

--- a/app/components/maps/OrganizationDetailsModal.tsx
+++ b/app/components/maps/OrganizationDetailsModal.tsx
@@ -1,0 +1,313 @@
+import React, { useMemo } from 'react';
+import { Modal, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import Icon from '@expo/vector-icons/MaterialIcons';
+
+import type { Organization } from '../../types/organization';
+
+type ThemeColors = {
+  primary: string;
+  secondary: string;
+  background: string;
+  surface: string;
+  text: string;
+  border: string;
+  success: string;
+  warning: string;
+  error: string;
+};
+
+type Props = {
+  visible: boolean;
+  organization: Organization | null;
+  colors: ThemeColors;
+  locationText: string;
+  onClose: () => void;
+  onEdit: () => void;
+  onDirections: () => void;
+  onScheduleMeeting: () => void;
+  onPressPhone: (phone?: string) => void;
+  onPressWhatsApp: (phone?: string) => void;
+  onPressWebsite: (website?: string) => void;
+};
+
+type DetailEntry = {
+  key: string;
+  icon: string;
+  text: string;
+  onPress?: () => void;
+};
+
+const OrganizationDetailsModal: React.FC<Props> = ({
+  visible,
+  organization,
+  colors,
+  locationText,
+  onClose,
+  onEdit,
+  onDirections,
+  onScheduleMeeting,
+  onPressPhone,
+  onPressWhatsApp,
+  onPressWebsite,
+}) => {
+  const details = useMemo<DetailEntry[]>(() => {
+    if (!organization) {
+      return [];
+    }
+
+    const normalize = (value?: string) => value?.trim() ?? '';
+
+    const entries: DetailEntry[] = [];
+
+    if (normalize(organization.category)) {
+      entries.push({ key: 'category', icon: 'business', text: organization.category });
+    }
+
+    const locationParts = [normalize(organization.city), normalize(organization.state)].filter(Boolean);
+    const fallbackLocation = locationParts.join(', ');
+    const resolvedLocation = normalize(locationText) || fallbackLocation;
+    if (normalize(resolvedLocation)) {
+      entries.push({ key: 'location', icon: 'location-city', text: resolvedLocation });
+    }
+
+    if (normalize(organization.contact)) {
+      entries.push({
+        key: 'contact',
+        icon: 'phone',
+        text: organization.contact!,
+        onPress: () => onPressPhone(organization.contact),
+      });
+    }
+
+    if (normalize(organization.description)) {
+      entries.push({ key: 'description', icon: 'info', text: organization.description! });
+    }
+
+    if (normalize(organization.type)) {
+      entries.push({ key: 'type', icon: 'category', text: `Type: ${organization.type}` });
+    }
+
+    if (normalize(organization.ratings)) {
+      entries.push({ key: 'ratings', icon: 'star', text: `Ratings: ${organization.ratings}` });
+    }
+
+    if (normalize(organization.website)) {
+      entries.push({
+        key: 'website',
+        icon: 'web',
+        text: `Website: ${organization.website}`,
+        onPress: () => onPressWebsite(organization.website),
+      });
+    }
+
+    if (normalize(organization.numberOfStudents)) {
+      entries.push({
+        key: 'students',
+        icon: 'school',
+        text: `Students: ${organization.numberOfStudents}`,
+      });
+    }
+
+    if (normalize(organization.decisionMakerName)) {
+      entries.push({
+        key: 'decisionMaker',
+        icon: 'person',
+        text: `Decision Maker: ${organization.decisionMakerName}`,
+      });
+    }
+
+    if (normalize(organization.phoneDM)) {
+      entries.push({
+        key: 'phoneDM',
+        icon: 'phone',
+        text: `DM Phone: ${organization.phoneDM}`,
+        onPress: () => onPressPhone(organization.phoneDM),
+      });
+    }
+
+    if (normalize(organization.whatsapp)) {
+      entries.push({
+        key: 'whatsapp',
+        icon: 'chat',
+        text: `WhatsApp: ${organization.whatsapp}`,
+        onPress: () => onPressWhatsApp(organization.whatsapp),
+      });
+    }
+
+    if (normalize(organization.currentStatus)) {
+      entries.push({
+        key: 'currentStatus',
+        icon: 'update',
+        text: `Current Status: ${organization.currentStatus}`,
+      });
+    }
+
+    if (normalize(organization.currentStatusDetails)) {
+      entries.push({
+        key: 'currentStatusDetails',
+        icon: 'description',
+        text: `Status Details: ${organization.currentStatusDetails}`,
+      });
+    }
+
+    if (normalize(organization.beforeSchool)) {
+      entries.push({
+        key: 'beforeSchool',
+        icon: 'watch-later',
+        text: `Before School: ${organization.beforeSchool}`,
+      });
+    }
+
+    if (normalize(organization.afterSchool)) {
+      entries.push({
+        key: 'afterSchool',
+        icon: 'event-available',
+        text: `After School: ${organization.afterSchool}`,
+      });
+    }
+
+    if (normalize(organization.addOns)) {
+      entries.push({ key: 'addOns', icon: 'extension', text: `Add-ons: ${organization.addOns}` });
+    }
+
+    if (normalize(organization.eventTitle)) {
+      entries.push({ key: 'eventTitle', icon: 'event', text: `Event: ${organization.eventTitle}` });
+    }
+
+    if (normalize(organization.startDate) && normalize(organization.startTime)) {
+      entries.push({
+        key: 'start',
+        icon: 'schedule',
+        text: `Start: ${organization.startDate} at ${organization.startTime}`,
+      });
+    }
+
+    return entries;
+  }, [organization, locationText, onPressPhone, onPressWebsite, onPressWhatsApp]);
+
+  return (
+    <Modal visible={visible && !!organization} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.modalOverlay}>
+        <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
+          <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
+            <Text style={[styles.modalTitle, { color: colors.text }]}>{organization?.name}</Text>
+            <TouchableOpacity onPress={onClose} accessibilityRole="button">
+              <Icon name="close" size={24} color={colors.text} />
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView style={styles.modalBody} showsVerticalScrollIndicator={false}>
+            {details.map((detail) => (
+              <TouchableOpacity
+                key={detail.key}
+                style={styles.detailRow}
+                onPress={detail.onPress}
+                activeOpacity={detail.onPress ? 0.7 : 1}
+                disabled={!detail.onPress}
+              >
+                <Icon name={detail.icon} size={20} color={colors.primary} />
+                <Text style={[styles.detailText, { color: colors.text }]}>{detail.text}</Text>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+
+          <View style={[styles.modalFooter, { borderTopColor: colors.border }]}>
+            <View style={styles.footerButtonRow}>
+              <TouchableOpacity
+                style={[styles.actionButton, { backgroundColor: colors.warning }]}
+                onPress={onEdit}
+                activeOpacity={0.8}
+              >
+                <Icon name="edit" size={20} color="#fff" />
+                <Text style={styles.actionButtonText}>Edit</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={[styles.actionButton, { backgroundColor: colors.success }]}
+                onPress={onDirections}
+                activeOpacity={0.8}
+              >
+                <Icon name="directions" size={20} color="#fff" />
+                <Text style={styles.actionButtonText}>Directions</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={[styles.actionButton, { backgroundColor: colors.primary }]}
+                onPress={onScheduleMeeting}
+                activeOpacity={0.8}
+              >
+                <Icon name="event" size={20} color="#fff" />
+                <Text style={styles.actionButtonText}>Schedule Meeting</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    maxHeight: '80%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 20,
+    borderBottomWidth: 1,
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  modalBody: {
+    padding: 20,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  detailText: {
+    marginLeft: 12,
+    fontSize: 16,
+    flex: 1,
+  },
+  modalFooter: {
+    padding: 20,
+    borderTopWidth: 1,
+  },
+  footerButtonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    flex: 1,
+    marginHorizontal: 6,
+  },
+  actionButtonText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+    marginLeft: 8,
+  },
+});
+
+export default OrganizationDetailsModal;
+


### PR DESCRIPTION
## Summary
- extract the organization detail, edit, and meeting dialogs into reusable components under `app/components/maps`
- simplify `MapsScreen` by wiring the new modal components and moving form state initialization helpers alongside their usage
- add typed helpers for meeting form updates while preserving existing linking handlers

## Testing
- `npm run lint` *(fails: expo CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68cd16c3ba3c8325a7be2a5fe0a73b61