### PR TITLE
Add structured dropdowns and multi-selects to edit organization modal

### DIFF
--- a/app/components/maps/EditOrganizationModal.tsx
+++ b/app/components/maps/EditOrganizationModal.tsx
@@ -25,20 +25,32 @@ export type EditFormState = {
   category: string;
   pulseCode: string;
   status: string;
+  currentPublication: string;
+  currentPublicationOther: string;
   currentStatus: string;
   currentStatusDetails: string;
   assignee: string;
+  guests: string[];
+  additionalGuests: string;
+  addOns: string[];
+  addOnsOther: string;
 };
 
 type Props = {
   visible: boolean;
   colors: ThemeColors;
   formData: EditFormState;
-  onChange: (field: keyof EditFormState, value: string) => void;
+  onChange: (field: keyof EditFormState, value: EditFormState[keyof EditFormState]) => void;
   onClose: () => void;
   onSubmit: () => void;
   organizationName?: Organization['name'];
   categoryOptions: string[];
+  currentPublicationOptions: string[];
+  currentStatusOptions: string[];
+  currentStatusDetailOptions: string[];
+  whatsappOptions: string[];
+  guestOptions: string[];
+  addOnOptions: string[];
   onOpenExternalForm?: () => void;
   previousSchools?: string | null;
 };
@@ -52,170 +64,279 @@ const EditOrganizationModal: React.FC<Props> = ({
   onSubmit,
   organizationName,
   categoryOptions,
+  currentPublicationOptions,
+  currentStatusOptions,
+  currentStatusDetailOptions,
+  whatsappOptions,
+  guestOptions,
+  addOnOptions,
   onOpenExternalForm,
   previousSchools,
-}) => (
-  <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
-    <View style={styles.modalOverlay}>
-      <View style={[styles.modalContent, { backgroundColor: colors.surface }]}> 
-        <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}> 
-          <View>
-            <Text style={[styles.modalTitle, { color: colors.text }]}>Edit Organization</Text>
-            {organizationName ? (
-              <Text style={[styles.modalSubtitle, { color: colors.secondary }]} numberOfLines={1}>
-                {organizationName}
-              </Text>
-            ) : null}
-          </View>
-          <TouchableOpacity onPress={onClose} accessibilityRole="button">
-            <Icon name="close" size={24} color={colors.text} />
-          </TouchableOpacity>
-        </View>
+}) => {
+  const handlePickerChange = (field: keyof EditFormState, value: string) => {
+    onChange(field, value);
 
-        <ScrollView style={styles.modalBody} showsVerticalScrollIndicator={false}>
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Name</Text>
-          <TextInput
-            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
-            value={formData.name}
-            onChangeText={(value) => onChange('name', value)}
-            placeholder="Organization name"
-            placeholderTextColor={colors.secondary}
-          />
+    if (field === 'currentPublication' && value !== 'Other') {
+      onChange('currentPublicationOther', '');
+    }
+  };
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Address</Text>
-          <TextInput
-            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
-            value={formData.address}
-            onChangeText={(value) => onChange('address', value)}
-            placeholder="Organization address"
-            placeholderTextColor={colors.secondary}
-          />
+  const toggleSelection = (field: 'guests' | 'addOns', value: string) => {
+    const currentValues = formData[field] as string[];
+    const exists = currentValues.includes(value);
+    const nextValues = exists
+      ? currentValues.filter((item) => item !== value)
+      : [...currentValues, value];
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Phone</Text>
-          <TextInput
-            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
-            value={formData.contact}
-            onChangeText={(value) => onChange('contact', value)}
-            placeholder="Primary phone number"
-            placeholderTextColor={colors.secondary}
-            keyboardType="phone-pad"
-          />
+    onChange(field, nextValues);
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>WhatsApp</Text>
-          <TextInput
-            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
-            value={formData.whatsapp}
-            onChangeText={(value) => onChange('whatsapp', value)}
-            placeholder="WhatsApp contact"
-            placeholderTextColor={colors.secondary}
-            keyboardType="phone-pad"
-          />
+    if (field === 'addOns' && value === 'Other' && exists) {
+      onChange('addOnsOther', '');
+    }
+  };
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Category</Text>
-          {categoryOptions.length > 0 ? (
-            <View style={[styles.pickerContainer, { borderColor: colors.border }]}>
-              <Picker
-                selectedValue={formData.category}
-                onValueChange={(value) => onChange('category', value)}
-                style={[styles.picker, { color: colors.text }]}
-                dropdownIconColor={colors.text}
-              >
-                {categoryOptions.map((option) => (
-                  <Picker.Item key={option} label={option} value={option} />
-                ))}
-              </Picker>
+  const renderPicker = (options: string[], selectedValue: string, field: keyof EditFormState, placeholder: string) => (
+    <View style={[styles.pickerContainer, { borderColor: colors.border }]}>
+      <Picker
+        selectedValue={selectedValue}
+        onValueChange={(value) => handlePickerChange(field, value)}
+        style={[styles.picker, { color: colors.text }]}
+        dropdownIconColor={colors.text}
+      >
+        <Picker.Item label={placeholder} value="" />
+        {options.map((option) => (
+          <Picker.Item key={option} label={option} value={option} />
+        ))}
+      </Picker>
+    </View>
+  );
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.modalOverlay}>
+        <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
+          <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
+            <View>
+              <Text style={[styles.modalTitle, { color: colors.text }]}>Edit Organization</Text>
+              {organizationName ? (
+                <Text style={[styles.modalSubtitle, { color: colors.secondary }]} numberOfLines={1}>
+                  {organizationName}
+                </Text>
+              ) : null}
             </View>
-          ) : (
+            <TouchableOpacity onPress={onClose} accessibilityRole="button">
+              <Icon name="close" size={24} color={colors.text} />
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView style={styles.modalBody} showsVerticalScrollIndicator={false}>
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Name</Text>
             <TextInput
               style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
-              value={formData.category}
-              onChangeText={(value) => onChange('category', value)}
-              placeholder="Category"
+              value={formData.name}
+              onChangeText={(value) => onChange('name', value)}
+              placeholder="Organization name"
               placeholderTextColor={colors.secondary}
             />
-          )}
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Pulse Code</Text>
-          <TextInput
-            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
-            value={formData.pulseCode}
-            onChangeText={(value) => onChange('pulseCode', value)}
-            placeholder="Pulse code"
-            placeholderTextColor={colors.secondary}
-          />
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Address</Text>
+            <TextInput
+              style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+              value={formData.address}
+              onChangeText={(value) => onChange('address', value)}
+              placeholder="Organization address"
+              placeholderTextColor={colors.secondary}
+            />
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Status</Text>
-          <TextInput
-            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
-            value={formData.status}
-            onChangeText={(value) => onChange('status', value)}
-            placeholder="Current status"
-            placeholderTextColor={colors.secondary}
-          />
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Phone</Text>
+            <TextInput
+              style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+              value={formData.contact}
+              onChangeText={(value) => onChange('contact', value)}
+              placeholder="Primary phone number"
+              placeholderTextColor={colors.secondary}
+              keyboardType="phone-pad"
+            />
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Current Status</Text>
-          <TextInput
-            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
-            value={formData.currentStatus}
-            onChangeText={(value) => onChange('currentStatus', value)}
-            placeholder="Current status summary"
-            placeholderTextColor={colors.secondary}
-          />
+            <Text style={[styles.inputLabel, { color: colors.text }]}>WhatsApp</Text>
+            {renderPicker(whatsappOptions, formData.whatsapp, 'whatsapp', 'Select WhatsApp status')}
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Status Details</Text>
-          <TextInput
-            style={[styles.textArea, { borderColor: colors.border, color: colors.text }]}
-            value={formData.currentStatusDetails}
-            onChangeText={(value) => onChange('currentStatusDetails', value)}
-            placeholder="Additional details"
-            placeholderTextColor={colors.secondary}
-            multiline
-          />
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Category</Text>
+            {categoryOptions.length > 0 ? (
+              renderPicker(categoryOptions, formData.category, 'category', 'Select category')
+            ) : (
+              <TextInput
+                style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+                value={formData.category}
+                onChangeText={(value) => onChange('category', value)}
+                placeholder="Category"
+                placeholderTextColor={colors.secondary}
+              />
+            )}
 
-          <Text style={[styles.inputLabel, { color: colors.text }]}>Assignee</Text>
-          <TextInput
-            style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
-            value={formData.assignee}
-            onChangeText={(value) => onChange('assignee', value)}
-            placeholder="Assigned to"
-            placeholderTextColor={colors.secondary}
-          />
-
-          {previousSchools ? (
-            <View style={[styles.infoBox, { borderColor: colors.border, backgroundColor: colors.background }]}>
-              <Text style={[styles.infoTitle, { color: colors.text }]}>Previous Schools</Text>
-              <Text style={[styles.infoText, { color: colors.secondary }]}>{previousSchools}</Text>
-            </View>
-          ) : null}
-        </ScrollView>
-
-        <View style={[styles.modalFooter, { borderTopColor: colors.border }]}>
-          <View style={styles.footerActions}>
-            {onOpenExternalForm ? (
-              <TouchableOpacity
-                style={[styles.secondaryButton, { borderColor: colors.primary }]}
-                onPress={onOpenExternalForm}
-                activeOpacity={0.85}
-              >
-                <Icon name="open-in-new" size={20} color={colors.primary} />
-                <Text style={[styles.secondaryText, { color: colors.primary }]}>Open Full Form</Text>
-              </TouchableOpacity>
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Current Publication</Text>
+            {renderPicker(
+              currentPublicationOptions,
+              formData.currentPublication,
+              'currentPublication',
+              'Select publication'
+            )}
+            {formData.currentPublication === 'Other' ? (
+              <TextInput
+                style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+                value={formData.currentPublicationOther}
+                onChangeText={(value) => onChange('currentPublicationOther', value)}
+                placeholder="Enter publication name"
+                placeholderTextColor={colors.secondary}
+              />
             ) : null}
 
-            <TouchableOpacity
-              style={[styles.submitButton, { backgroundColor: colors.primary }]}
-              onPress={onSubmit}
-              activeOpacity={0.85}
-            >
-              <Icon name="save" size={20} color="#fff" />
-              <Text style={styles.submitText}>Save Changes</Text>
-            </TouchableOpacity>
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Pulse Code</Text>
+            <TextInput
+              style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+              value={formData.pulseCode}
+              onChangeText={(value) => onChange('pulseCode', value)}
+              placeholder="Pulse code"
+              placeholderTextColor={colors.secondary}
+            />
+
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Status</Text>
+            <TextInput
+              style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+              value={formData.status}
+              onChangeText={(value) => onChange('status', value)}
+              placeholder="Status"
+              placeholderTextColor={colors.secondary}
+            />
+
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Current Status</Text>
+            {renderPicker(currentStatusOptions, formData.currentStatus, 'currentStatus', 'Select status')}
+
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Current Status Details</Text>
+            {renderPicker(
+              currentStatusDetailOptions,
+              formData.currentStatusDetails,
+              'currentStatusDetails',
+              'Select status details'
+            )}
+
+            <Text style={[styles.inputLabel, { color: colors.text }]}>Assignee</Text>
+            <TextInput
+              style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+              value={formData.assignee}
+              onChangeText={(value) => onChange('assignee', value)}
+              placeholder="Assigned to"
+              placeholderTextColor={colors.secondary}
+            />
+
+            <Text style={[styles.sectionLabel, { color: colors.text }]}>Guests</Text>
+            <View style={styles.multiSelectContainer}>
+              {guestOptions.map((option) => {
+                const selected = formData.guests.includes(option);
+                return (
+                  <TouchableOpacity
+                    key={option}
+                    style={[
+                      styles.multiSelectOption,
+                      {
+                        borderColor: selected ? colors.primary : colors.border,
+                        backgroundColor: selected ? 'rgba(0,0,0,0.04)' : 'transparent',
+                      },
+                    ]}
+                    onPress={() => toggleSelection('guests', option)}
+                    activeOpacity={0.75}
+                  >
+                    <Icon
+                      name={selected ? 'check-box' : 'check-box-outline-blank'}
+                      size={20}
+                      color={selected ? colors.primary : colors.secondary}
+                    />
+                    <Text style={[styles.multiSelectOptionText, { color: colors.text }]}>{option}</Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+            <TextInput
+              style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+              value={formData.additionalGuests}
+              onChangeText={(value) => onChange('additionalGuests', value)}
+              placeholder="Additional guests (comma separated)"
+              placeholderTextColor={colors.secondary}
+            />
+
+            <Text style={[styles.sectionLabel, { color: colors.text }]}>Add-ons</Text>
+            <View style={styles.multiSelectContainer}>
+              {addOnOptions.map((option) => {
+                const selected = formData.addOns.includes(option);
+                return (
+                  <TouchableOpacity
+                    key={option}
+                    style={[
+                      styles.multiSelectOption,
+                      {
+                        borderColor: selected ? colors.primary : colors.border,
+                        backgroundColor: selected ? 'rgba(0,0,0,0.04)' : 'transparent',
+                      },
+                    ]}
+                    onPress={() => toggleSelection('addOns', option)}
+                    activeOpacity={0.75}
+                  >
+                    <Icon
+                      name={selected ? 'check-box' : 'check-box-outline-blank'}
+                      size={20}
+                      color={selected ? colors.primary : colors.secondary}
+                    />
+                    <Text style={[styles.multiSelectOptionText, { color: colors.text }]}>{option}</Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+            {formData.addOns.includes('Other') ? (
+              <TextInput
+                style={[styles.textInput, { borderColor: colors.border, color: colors.text }]}
+                value={formData.addOnsOther}
+                onChangeText={(value) => onChange('addOnsOther', value)}
+                placeholder="Enter additional add-ons"
+                placeholderTextColor={colors.secondary}
+              />
+            ) : null}
+
+            {previousSchools ? (
+              <View style={[styles.infoBox, { borderColor: colors.border, backgroundColor: colors.background }]}>
+                <Text style={[styles.infoTitle, { color: colors.text }]}>Previous Schools</Text>
+                <Text style={[styles.infoText, { color: colors.secondary }]}>{previousSchools}</Text>
+              </View>
+            ) : null}
+          </ScrollView>
+
+          <View style={[styles.modalFooter, { borderTopColor: colors.border }]}>
+            <View style={styles.footerActions}>
+              {onOpenExternalForm ? (
+                <TouchableOpacity
+                  style={[styles.secondaryButton, { borderColor: colors.primary }]}
+                  onPress={onOpenExternalForm}
+                  activeOpacity={0.85}
+                >
+                  <Icon name="open-in-new" size={20} color={colors.primary} />
+                  <Text style={[styles.secondaryText, { color: colors.primary }]}>Open Full Form</Text>
+                </TouchableOpacity>
+              ) : null}
+
+              <TouchableOpacity
+                style={[styles.submitButton, { backgroundColor: colors.primary }]}
+                onPress={onSubmit}
+                activeOpacity={0.85}
+              >
+                <Icon name="save" size={20} color="#fff" />
+                <Text style={styles.submitText}>Save Changes</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         </View>
       </View>
-    </View>
-  </Modal>
-);
+    </Modal>
+  );
+};
 
 const styles = StyleSheet.create({
   modalOverlay: {
@@ -269,15 +390,11 @@ const styles = StyleSheet.create({
     height: 48,
     width: '100%',
   },
-  textArea: {
-    borderWidth: 1,
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
+  sectionLabel: {
     fontSize: 16,
-    minHeight: 100,
-    textAlignVertical: 'top',
-    marginBottom: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+    marginTop: 8,
   },
   modalFooter: {
     padding: 20,
@@ -316,6 +433,25 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginLeft: 8,
+  },
+  multiSelectContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 16,
+  },
+  multiSelectOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    marginRight: 8,
+    marginBottom: 8,
+  },
+  multiSelectOptionText: {
+    fontSize: 14,
+    marginLeft: 6,
   },
   infoBox: {
     borderWidth: 1,

--- a/app/components/maps/OrganizationDetailsModal.tsx
+++ b/app/components/maps/OrganizationDetailsModal.tsx
@@ -79,6 +79,22 @@ const OrganizationDetailsModal: React.FC<Props> = ({
       });
     }
 
+    if (normalize(organization.status)) {
+      entries.push({ key: 'status', icon: 'assignment', text: `Status: ${organization.status}` });
+    }
+
+    if (normalize(organization.currentPublicationName)) {
+      entries.push({
+        key: 'currentPublication',
+        icon: 'menu-book',
+        text: `Current Publication: ${organization.currentPublicationName}`,
+      });
+    }
+
+    if (normalize(organization.pulseCode)) {
+      entries.push({ key: 'pulseCode', icon: 'qr-code', text: `Pulse Code: ${organization.pulseCode}` });
+    }
+
     if (normalize(organization.description)) {
       entries.push({ key: 'description', icon: 'info', text: organization.description! });
     }
@@ -132,6 +148,10 @@ const OrganizationDetailsModal: React.FC<Props> = ({
         text: `WhatsApp: ${organization.whatsapp}`,
         onPress: () => onPressWhatsApp(organization.whatsapp),
       });
+    }
+
+    if (normalize(organization.guests)) {
+      entries.push({ key: 'guests', icon: 'group', text: `Guests: ${organization.guests}` });
     }
 
     if (normalize(organization.currentStatus)) {

--- a/app/screens/maps/constants.ts
+++ b/app/screens/maps/constants.ts
@@ -1,6 +1,120 @@
 import type { EditFormState } from '../../components/maps/EditOrganizationModal';
 import type { MeetingFormState } from '../../components/maps/MeetingRequestModal';
 
+export const CATEGORY_OPTIONS: string[] = [
+  'Standalone School',
+  'Standalone Preschool',
+  'Multibranch School',
+  'Multibranch preschool',
+  'Small Franchise Preschool',
+  'Small Franchise School',
+  'Large Franchise Preschool',
+  'Large Franchise School',
+  'No details',
+  'Vinuth',
+  'Delete',
+];
+
+export const CURRENT_PUBLICATION_OPTIONS: string[] = [
+  'Eduvate',
+  'Navneet',
+  'Springboard(Jeevandeep)',
+  'Iceberg',
+  'Lil Beez',
+  'Kreedo',
+  'Next Primes Monthly',
+  'Next Yearly',
+  'Macmillan',
+  'Shubash',
+  'Cambridge',
+  'Oxford',
+  'Academy',
+  'Smart kindergarten',
+  'Dream land',
+  'Black swan',
+  'Mixed',
+  'Tinker Next',
+  'Other',
+];
+
+export const CURRENT_STATUS_OPTIONS: string[] = [
+  'Verified',
+  'Demo Rejected',
+  'WO Demo Rejected',
+  'Demo Scheduled',
+  'Waiting for approval',
+  'SLA Done',
+  'Interested',
+  'Not Interested',
+  'Drop physical samples',
+];
+
+export const CURRENT_STATUS_DETAIL_OPTIONS: string[] = [
+  'Seeking Appointment',
+  'Demo Done',
+  'Appointemnt Scheduled',
+  'Interested',
+  'Follow up pending',
+  'Converted',
+  'Physical samples to be dropped',
+  'Samples dropped',
+  'Awaiting Confirmation',
+  'Not interested',
+  'No response',
+  'Need to talk to higher management',
+  'Awaiting token advance',
+  'Already have stock/ in agreement',
+  'Already have stock/ in agreement( revisit next year)',
+];
+
+export const WHATSAPP_OPTIONS: string[] = ['To Create', "Don't create", 'Done'];
+
+export const GUEST_OPTIONS: string[] = [
+  'vinuthshiv@gmail.com',
+  'praphul09@gmail.com',
+  'sangumuttu114@gmail.com',
+  'd.narendran.pixarttechnologies@gmail.com',
+  'manoj.pixart1@gmail.com',
+  'unplugstories2@gmail.com',
+  'preetampixart@gmail.co',
+];
+
+export const ADD_ON_OPTIONS: string[] = [
+  'Books',
+  'Uniform',
+  'Bag',
+  'ID Cards',
+  'Certificates',
+  'Calendar',
+  'Report cards',
+  'Stationery items',
+  'Greeting cards',
+  'Pop up book',
+  'Gifting book',
+  'Lanyard',
+  'Language Books',
+  'Other',
+];
+
+export const FORM_ENTRY_IDS = {
+  name: 'entry.1000000000',
+  address: 'entry.1000000001',
+  contact: 'entry.1000000002',
+  whatsapp: 'entry.1000000003',
+  category: 'entry.1748805668',
+  pulseCode: 'entry.1000000004',
+  status: 'entry.1000000005',
+  currentPublication: 'entry.1000000006',
+  currentPublicationOther: 'entry.1000000007',
+  currentStatus: 'entry.1000000008',
+  currentStatusDetails: 'entry.1523910384',
+  assignee: 'entry.1000000009',
+  guests: 'entry.1000000010',
+  additionalGuests: 'entry.1000000011',
+  addOns: 'entry.1000000012',
+  addOnsOther: 'entry.1000000013',
+};
+
 export const INITIAL_EDIT_FORM: EditFormState = {
   name: '',
   address: '',
@@ -9,9 +123,15 @@ export const INITIAL_EDIT_FORM: EditFormState = {
   category: '',
   pulseCode: '',
   status: '',
+  currentPublication: '',
+  currentPublicationOther: '',
   currentStatus: '',
   currentStatusDetails: '',
   assignee: '',
+  guests: [],
+  additionalGuests: '',
+  addOns: [],
+  addOnsOther: '',
 };
 
 export const INITIAL_MEETING_FORM: MeetingFormState = {


### PR DESCRIPTION
## Summary
- replace manual text inputs in the edit organization modal with dropdowns for category, publication, statuses, WhatsApp status, and chip-style selectors for guests and add-ons
- capture additional metadata in the edit form state, provide default option lists, and wire the values through MapsScreen including the external form parameter helper
- surface the newly captured fields in the organization details modal and define placeholder form entry identifiers for all supported fields

## Testing
- npm run lint *(fails: expo CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68cd45fa0f888325af0ee94cd542ce75