### PR TITLE
Ensure organization markers use stable unique keys

### DIFF
--- a/app/components/ClusteredMarkers.tsx
+++ b/app/components/ClusteredMarkers.tsx
@@ -163,9 +163,13 @@ const ClusteredMarkersComponent: React.FC<ClusteredMarkersProps> = ({ organizati
         }
 
         if (properties.organization) {
+          const organizationKey =
+            properties.organization.mapsUrl ??
+            `${properties.organization.name}-${latitude}-${longitude}`;
+
           return (
             <OrganizationMarker
-              key={`org-${properties.organization.id}`}
+              key={`org-${organizationKey}`}
               org={properties.organization}
               onPress={onMarkerPress}
             />


### PR DESCRIPTION
## Summary
- derive unique marker keys from stable organization fields to avoid duplicated React keys

## Testing
- npm run lint *(fails: expo command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce8d0f0fc48325b52e6fd6e0711814