### PR TITLE
Fix maps meeting submission types and filter props

### DIFF
--- a/app/components/filter.tsx
+++ b/app/components/filter.tsx
@@ -3,19 +3,11 @@ import { View, StyleSheet, TouchableOpacity, Dimensions, Text } from 'react-nati
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import { Picker } from '@react-native-picker/picker';
 import { moderateScale } from 'react-native-size-matters';
-
-interface org {
-  id: string;
-  name: string;
-  category: string;
-  currentStatus?: string;
-  city: string;
-  state: string;
-}
+import type { Organization } from '../types/organization';
 
 type FilterProps = {
-  allMarkers: org[];
-  setFilteredMarkers: (markers: org[]) => void;
+  allMarkers: Organization[];
+  setFilteredMarkers: (markers: Organization[]) => void;
 };
 
 const Filter: React.FC<FilterProps> = ({ allMarkers, setFilteredMarkers }) => {

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -9,6 +9,7 @@ import {
   Platform,
   ToastAndroid,
   Linking,
+  Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../../src/context/AuthContext';


### PR DESCRIPTION
## Summary
- align the map meeting submission logic with the MeetingRequestModal form shape and guard against missing organizations or invalid times
- reuse the shared Organization type in the filter control so marker filtering accepts the same objects emitted by the map

## Testing
- npm run lint *(fails: expo CLI is unavailable in the execution environment)*
- npx tsc --noEmit *(fails: project depends on Expo's tsconfig base and React Native typings that are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cea2b7acb08325bb6c17f11944e19c