### PR TITLE
Revamp maps screen layout and toolbar

### DIFF
--- a/app/screens/maps/CategoryLegend.tsx
+++ b/app/screens/maps/CategoryLegend.tsx
@@ -8,16 +8,35 @@ import type { ThemeColors } from './types';
 interface CategoryLegendProps {
   categories: string[];
   colors: ThemeColors;
+  variant?: 'default' | 'overlay';
 }
 
-const CategoryLegend: React.FC<CategoryLegendProps> = ({ categories, colors }) => {
+const CategoryLegend: React.FC<CategoryLegendProps> = ({ categories, colors, variant = 'default' }) => {
   if (categories.length === 0) {
     return null;
   }
 
+  const containerStyles = [
+    styles.legendContainer,
+    { backgroundColor: colors.surface },
+  ];
+
+  if (variant === 'overlay') {
+    containerStyles.push(styles.legendOverlayContainer, { backgroundColor: 'transparent' });
+  }
+
   return (
-    <View style={[styles.legendContainer, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.legendText, { fontWeight: 'bold', marginBottom: 8, color: colors.text }]}>Categories:</Text>
+    <View style={containerStyles}>
+      <Text
+        style={[
+          styles.legendText,
+          styles.legendTitle,
+          { color: colors.text },
+          variant === 'overlay' && styles.legendOverlayTitle,
+        ]}
+      >
+        Categories
+      </Text>
       <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.legendScroll}>
         {categories.map((category) => (
           <View key={category} style={styles.legendItem}>

--- a/app/screens/maps/LiveTrackingLegend.tsx
+++ b/app/screens/maps/LiveTrackingLegend.tsx
@@ -8,16 +8,40 @@ interface LiveTrackingLegendProps {
   liveUsers: LiveTrackingUser[];
   colors: ThemeColors;
   colorMap: Record<string, string>;
+  variant?: 'default' | 'overlay';
 }
 
-const LiveTrackingLegend: React.FC<LiveTrackingLegendProps> = ({ liveUsers, colors, colorMap }) => {
+const LiveTrackingLegend: React.FC<LiveTrackingLegendProps> = ({
+  liveUsers,
+  colors,
+  colorMap,
+  variant = 'default',
+}) => {
   if (liveUsers.length === 0) {
     return null;
   }
 
+  const containerStyles = [
+    styles.legendContainer,
+    { backgroundColor: colors.surface },
+  ];
+
+  if (variant === 'overlay') {
+    containerStyles.push(styles.legendOverlayContainer, { backgroundColor: 'transparent' });
+  }
+
   return (
-    <View style={[styles.legendContainer, { backgroundColor: colors.surface }]}> 
-      <Text style={[styles.legendText, { fontWeight: 'bold', marginBottom: 8, color: colors.text }]}>Live Tracking Users:</Text>
+    <View style={containerStyles}>
+      <Text
+        style={[
+          styles.legendText,
+          styles.legendTitle,
+          { color: colors.text },
+          variant === 'overlay' && styles.legendOverlayTitle,
+        ]}
+      >
+        Live Tracking Users
+      </Text>
       <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.legendScroll}>
         {liveUsers.map((liveUser, index) => {
           const colorKey = liveUser.userId || liveUser.name || `user-${index}`;

--- a/app/screens/maps/MapContent.tsx
+++ b/app/screens/maps/MapContent.tsx
@@ -92,7 +92,6 @@ const MapContent: React.FC<MapContentProps> = ({
       </View>
     ) : (
       <MapView
-        key={`map-${organizations.length}`}
         style={styles.map}
         provider={PROVIDER_GOOGLE}
         initialRegion={computedMapRegion}

--- a/app/screens/maps/styles.ts
+++ b/app/screens/maps/styles.ts
@@ -4,9 +4,18 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
+  screenContent: {
+    flex: 1,
+  },
+  searchSection: {
+    flex: 8,
+    justifyContent: 'center',
+  },
   searchContainer: {
+    flex: 1,
+    justifyContent: 'center',
     paddingHorizontal: 16,
-    paddingVertical: 0,
+    paddingVertical: 8,
   },
   searchBar: {
     flexDirection: 'row',
@@ -25,7 +34,12 @@ const styles = StyleSheet.create({
     marginLeft: 8,
     fontSize: 16,
   },
+  assignedWrapper: {
+    flex: 7,
+    justifyContent: 'center',
+  },
   assignedSection: {
+    flexShrink: 0,
     marginHorizontal: 16,
     marginBottom: 8,
     paddingVertical: 8,
@@ -115,9 +129,12 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
   },
+  mapSection: {
+    flex: 85,
+    position: 'relative',
+  },
   mapContainer: {
     flex: 1,
-    marginTop: 4,
   },
   map: {
     flex: 1,
@@ -150,6 +167,109 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 16,
     fontSize: 16,
+  },
+  mapOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    padding: 16,
+    justifyContent: 'flex-start',
+  },
+  toolbarWrapper: {
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.12,
+    shadowRadius: 6,
+    elevation: 4,
+  },
+  toolbarScroll: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: 12,
+  },
+  toolbarButtonWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  toolbarButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+  },
+  toolbarButtonText: {
+    marginLeft: 6,
+    fontWeight: '600',
+  },
+  toolbarClearButton: {
+    marginLeft: 8,
+    padding: 6,
+    borderRadius: 10,
+    borderWidth: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  toolbarSwitch: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+  },
+  toolbarSwitchLabel: {
+    marginLeft: 6,
+    marginRight: 8,
+    fontWeight: '600',
+  },
+  badge: {
+    marginLeft: 8,
+    minWidth: 20,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  badgeText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  overlayPanels: {
+    marginTop: 12,
+    rowGap: 12,
+  },
+  overlayCard: {
+    borderRadius: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  filterDropdown: {
+    left: 0,
+    right: 0,
+  },
+  legendTitle: {
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  legendOverlayContainer: {
+    borderBottomWidth: 0,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 8,
+  },
+  legendOverlayTitle: {
+    marginBottom: 12,
   },
 });
 


### PR DESCRIPTION
## Summary
- restructure the maps screen layout so the map occupies the majority of the viewport with dedicated sections for search and assigned areas
- add a consolidated toolbar over the map for marker filters, clustering, category legend, and live tracking controls
- update shared components to support the new overlay toolbar and remove the map remount that caused instability with many markers

## Testing
- npm run lint *(fails: expo command missing in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ceaa9bdc6c8325aede6cf3663cc0af